### PR TITLE
deps: pin versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PySide6
-python-registry
+PySide6==6.2.3
+python-registry==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
-        "PySide6",
-        "python-registry"
+        "PySide6==6.2.3",
+        "python-registry==1.3.1"
     ],
     entry_points={
         "console_scripts": ["registryspy=registryspy.registryspy:main"],


### PR DESCRIPTION
If people try to install via pip or from cloning the repo, we're unable to run the software due to mismatching versions.

The interfaces of the dependencies have changed since your last release, and it pulls a more recent version that what you coded against.

This locks both dependencies down to what would've been the latest version at your last commit.

Before, both when installing from pip or cloning the repo, we got this error:

```
qt.dbus.integration: Could not connect "org.freedesktop.IBus" to globalEngineChanged(QString)
Traceback (most recent call last):
  File "/home/seth/Documents/repos/contributor/andyjsmith/Registry-Spy/run.py", line 4, in <module>
    registryspy.registryspy.main()
  File "/home/seth/Documents/repos/contributor/andyjsmith/Registry-Spy/registryspy/registryspy.py", line 283, in main
    reg_viewer = RegViewer()
  File "/home/seth/Documents/repos/contributor/andyjsmith/Registry-Spy/registryspy/registryspy.py", line 161, in __init__
    self.hive_info = hive_info_table.HiveInfoTable(tree_container)
  File "/home/seth/Documents/repos/contributor/andyjsmith/Registry-Spy/registryspy/hive_info_table.py", line 31, in __init__
    self.verticalHeader().setSectionResizeMode(self.verticalHeader().Fixed)
AttributeError: 'PySide6.QtWidgets.QHeaderView' object has no attribute 'Fixed'
```

After this change, we can just use the program as expected. :+1: 