### PR TITLE
feat: add widget to view human-readable value

### DIFF
--- a/registryspy/data_viewer.py
+++ b/registryspy/data_viewer.py
@@ -1,0 +1,48 @@
+import PySide6.QtGui as QtGui
+import PySide6.QtWidgets as QtWidgets
+
+
+class DataViewer(QtWidgets.QSplitter):
+    """Viewer to preview data of the selected registry key entry."""
+
+    def __init__(self):
+        super().__init__(QtGui.Qt.Orientation.Horizontal)
+
+        mono_font = QtGui.QFont()
+        mono_font.setFamilies(["DejaVu Sans Mono", "Courier New", "Monospaced"])
+        mono_font.setStyleHint(QtGui.QFont.Monospace)
+
+        self.value_hex = self.add_data_viewer(mono_font)
+        self.value_ascii = self.add_data_viewer(mono_font)
+
+    def add_data_viewer(self, font: QtGui.QFont):
+        """Create a data viewer widget and add it to this widget."""
+
+        viewer = QtWidgets.QPlainTextEdit()
+        viewer.setReadOnly(True)
+        viewer.setFont(font)
+        viewer.setLineWrapMode(viewer.LineWrapMode.NoWrap)
+        self.addWidget(viewer)
+        return viewer
+
+    def set_value(self, bytes: bytes):
+        """Set the value of all displayed viewers to the specified bytes."""
+
+        self.value_hex.setPlainText("")
+        self.value_ascii.setPlainText("")
+
+        def chunks(lst, n):
+            """Yield successive n-sized chunks from lst."""
+            for i in range(0, len(lst), n):
+                yield lst[i:i + n]
+
+        hex_text = ""
+        ascii_text = ""
+
+        for chunk in chunks(bytes, 16):
+            hex_text += " ".join(["{:02x}".format(x)
+                                  for x in chunk]) + "\n"
+            ascii_text += chunk.decode("windows-1252", "replace").replace(chr(0), ".") + "\n"
+
+        self.value_hex.setPlainText(hex_text)
+        self.value_ascii.setPlainText(ascii_text)

--- a/registryspy/registryspy.py
+++ b/registryspy/registryspy.py
@@ -4,6 +4,7 @@ import PySide6.QtGui as QtGui
 import PySide6.QtWidgets as QtWidgets
 import PySide6.QtCore as QtCore
 
+from . import data_viewer
 from . import value_table
 from . import key_tree
 from . import hive_info_table
@@ -167,16 +168,11 @@ class RegViewer(QtWidgets.QMainWindow):
             self.hive_info.SizeAdjustPolicy.AdjustToContents)
         tree_container_layout.addWidget(self.hive_info)
 
-        value_splitter = QtWidgets.QSplitter(
-            QtGui.Qt.Orientation.Vertical)
+        self.data_viewer = data_viewer.DataViewer()
+
+        value_splitter = QtWidgets.QSplitter(QtGui.Qt.Orientation.Vertical)
         value_splitter.addWidget(self.value_table)
-        self.value_hex = QtWidgets.QPlainTextEdit()
-        mono_font = QtGui.QFont()
-        mono_font.setFamilies(["Courier New", "Monospaced"])
-        mono_font.setStyleHint(QtGui.QFont.Monospace)
-        self.value_hex.setFont(mono_font)
-        self.value_hex.setLineWrapMode(self.value_hex.LineWrapMode.NoWrap)
-        value_splitter.addWidget(self.value_hex)
+        value_splitter.addWidget(self.data_viewer)
         value_splitter.setStretchFactor(0, 2)
         value_splitter.setStretchFactor(1, 1)
 

--- a/registryspy/value_table.py
+++ b/registryspy/value_table.py
@@ -59,24 +59,12 @@ class ValueTable(QtWidgets.QTableWidget):
         index = selected.indexes()[2]
 
         value: ValueData = self.itemFromIndex(index)
-
-        hex_text = ""
-
-        def chunks(lst, n):
-            """Yield successive n-sized chunks from lst."""
-            for i in range(0, len(lst), n):
-                yield lst[i:i + n]
-
-        for chunk in chunks(value.raw_data, 16):
-            hex_text += " ".join(["{:02x}".format(x)
-                                  for x in chunk]) + "\n"
-
-        self.window().value_hex.setPlainText(hex_text)
+        self.window().data_viewer.set_value(value.raw_data)
 
     def set_data(self, reg_values: "list[Registry.RegistryValue]"):
         self.clearContents()
         self.setRowCount(0)
-        self.window().value_hex.setPlainText("")
+        self.window().data_viewer.set_value(b"")
 
         for value in reg_values:
             index = self.rowCount()


### PR DESCRIPTION
Ultimately, this introduces a feature to show the plain-text input of the bytes alongside the hex.

I'm currently doing a course on forensics, and I'm using this instead of the software the course offered, but there was a difference I wanted to resolve.

![image](https://user-images.githubusercontent.com/22801583/230770143-e4eac127-99ad-4e18-8029-3d7bda25b8bf.png)
> Observe how next to the hex panel, there is also a human-readable text panel.

This seems like a worthwhile feature, especially I actually needed some of this information.

---

On the side I did a few chores:
* Encapsulate the data viewer into its own widget/panel.
* Add a font for the monospace text viewers, since it looks better on Linux systems.
* Set the text viewers to read-only. (Users shouldn't be able to type in them.)

### Screenshots

![image](https://user-images.githubusercontent.com/22801583/230770369-7b3bfeef-618f-4f95-a8fe-8b9c9833f44b.png)
> Here is how the same data looks in Registry Spy.

### Potential improvements

Some ideas for a future PR.

* Disable the scroll bars on the individual text widgets, and have a shared scroll bar for the DataViewer as a whole.
* Clicking/dragging on the hex bytes should anchor per hex byte, not per characters.
* Selecting bytes/chars should show the selection on the other side as well. (In my screenshot, I manually selected the same bytes.)